### PR TITLE
fix: add permission for ci.

### DIFF
--- a/.github/workflows/migrate-release.yaml
+++ b/.github/workflows/migrate-release.yaml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'v*'
 
+# Add permission for upstream repo.
+permissions:
+  contents: write
+
 jobs:
   build:
     name: Build and Release


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

1. Add `write` permission for release ci. https://github.com/softprops/action-gh-release?tab=readme-ov-file#permissions

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```